### PR TITLE
Roar of Time Copycat fix

### DIFF
--- a/assembly/data/move_tables.s
+++ b/assembly/data/move_tables.s
@@ -475,6 +475,7 @@ gAssistBannedMoves:
 .hword MOVE_TRICK
 .hword MOVE_WHIRLWIND
 .hword MOVE_OBSTRUCT
+.hword MOVE_ROAROFTIME
 .hword MOVE_TABLES_TERMIN
 
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@

--- a/assembly/data/move_tables.s
+++ b/assembly/data/move_tables.s
@@ -147,6 +147,7 @@ gCopycatBannedMoves:
 .hword MOVE_TRICK
 .hword MOVE_WHIRLWIND
 .hword MOVE_OBSTRUCT
+.hword MOVE_ROAROFTIME
 .hword MOVE_TABLES_TERMIN
 
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@


### PR DESCRIPTION
Forced switch moves are supposed to be blacklisted from copycat, see roar and whirlwind.